### PR TITLE
Add endpoints and dataclasses necessary for usage with Monitored VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Alternatively you can build and run the QProv Docker images by your own:
 1. Build the collector:
     `docker build -t collector -f Dockerfile-Collector .`
 2. Build the QProv system:
-    `docker build -t qprov -f Dockerfile-Web`
+    `docker build -t qprov -f Dockerfile-Web .`
 3. Run the Docker containers: `docker run -p 5020:5020 qprov` and `docker run -p 5021:5021 collector`
 
 Then, the QProv system can be accessed on <http://localhost:5020/qprov>. 

--- a/docs/dev/intellij-idea-code-style.xml
+++ b/docs/dev/intellij-idea-code-style.xml
@@ -1,5 +1,5 @@
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2020 the QProv contributors.
+  ~ Copyright (c) 2023 the QProv contributors.
   ~
   ~ See the NOTICE file(s) distributed with this work for additional
   ~ information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/CollectorService.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/CollectorService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/Constants.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/IProvider.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/IProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/QProvCollector.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/QProvCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQCircuitExecutor.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQCircuitExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQConstants.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQProvider.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQRunnableApi.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQRunnableApi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQRunnableCircuits.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQRunnableCircuits.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQUtility.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/IBMQUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/qiskit/service/QiskitServiceRequest.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/qiskit/service/QiskitServiceRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/qiskit/service/QiskitServiceResult.java
+++ b/org.quantil.qprov.collector/src/main/java/org/quantil/qprov/collector/providers/ibmq/qiskit/service/QiskitServiceResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/Constants.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/Constants.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/Constants.java
@@ -59,6 +59,8 @@ public final class Constants {
 
     public static final String QPROV_TYPE_QUBIT = "qubit";
 
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE = "virtualMachine";
+
     /**** QProv type attributes ****/
     public static final String QPROV_TYPE_SUFFIX = "Type";
 
@@ -127,6 +129,26 @@ public final class Constants {
     public static final String QPROV_TYPE_QUBIT_READOUT_ERROR = "readoutError";
 
     public static final String QPROV_TYPE_QUBIT_CALIBRATION_TIME = "calibrationTime";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_NAME = "virtualMachineName";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_CPU_NAME = "virtualMachineCpuName";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_CPU_CORES_COUNT = "virtualMachineCpuCoresCount";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_RAM_SIZE = "virtualMachineRamSize";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_DISK_SIZE = "virtualMachineDiskSize";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_RECORDING_TIME = "recordingTime";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_CPU_USAGE = "cpuUsage";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_CLOCK_SPEED = "clockSpeed";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_RAM_USAGE = "ramUsage";
+
+    public static final String QPROV_TYPE_VIRTUAL_MACHINE_DISK_USAGE = "diskUsage";
 
     /**** Default values ****/
 

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/ProvExtension.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/ProvExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/ProvTemplate.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/ProvTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/activities/CompileActivity.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/activities/CompileActivity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/activities/ExecuteActivity.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/activities/ExecuteActivity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/activities/PrepareDataActivity.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/activities/PrepareDataActivity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/Compiler.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/Compiler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/DataPreparationService.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/DataPreparationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/Provider.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/Provider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/QPU.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/QPU.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/VirtualMachine.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/VirtualMachine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/VirtualMachine.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/VirtualMachine.java
@@ -48,13 +48,10 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-
-
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Entity
 public class VirtualMachine extends org.openprovenance.prov.xml.Agent implements ProvExtension<VirtualMachine> {
-
 
     @Id
     @Getter

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/VirtualMachine.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/agents/VirtualMachine.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.core.model.agents;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.openprovenance.prov.model.Statement;
+import org.openprovenance.prov.xml.Agent;
+import org.quantil.qprov.core.Constants;
+import org.quantil.qprov.core.model.ProvExtension;
+import org.quantil.qprov.core.model.entities.HardwareCharacteristics;
+import org.quantil.qprov.core.utils.Utils;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Entity
+public class VirtualMachine extends org.openprovenance.prov.xml.Agent implements ProvExtension<VirtualMachine> {
+
+
+    @Id
+    @Getter
+    @Setter
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "databaseId", updatable = false, nullable = false)
+    private UUID databaseId;
+
+    private String name;
+
+    private String cpu;
+
+    private int cpuCores;
+
+    private int ramSize;
+
+    private int diskSize;
+
+    @OneToMany(mappedBy = "virtualMachine",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL,
+            orphanRemoval = true)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private Set<HardwareCharacteristics> hardwareCharacteristics = new HashSet<>();
+
+    @Override
+    public Set<Statement> toStandardCompliantProv(VirtualMachine extensionStatement) {
+        final Agent agent = new Agent();
+        agent.setId(Utils.generateQualifiedName(name, null));
+        agent.getType().add(Utils.createTypeElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE));
+        agent.getOther().add(Utils
+                .createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_NAME, name,
+                        Constants.QPROV_TYPE_VIRTUAL_MACHINE_NAME + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils
+                .createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_CPU_NAME, cpu,
+                        Constants.QPROV_TYPE_VIRTUAL_MACHINE_CPU_NAME + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils
+                .createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_CPU_CORES_COUNT, String.valueOf(cpuCores),
+                        Constants.QPROV_TYPE_VIRTUAL_MACHINE_CPU_CORES_COUNT + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils
+                .createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_RAM_SIZE, String.valueOf(ramSize),
+                        Constants.QPROV_TYPE_VIRTUAL_MACHINE_RAM_SIZE + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils
+                .createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_DISK_SIZE, String.valueOf(diskSize),
+                        Constants.QPROV_TYPE_VIRTUAL_MACHINE_DISK_SIZE + Constants.QPROV_TYPE_SUFFIX));
+
+        // add latest usage data
+        String recordingTime = Constants.QPROV_CHARACTERISTICS_NO_DATA;
+        String cpuUsage = Constants.QPROV_CHARACTERISTICS_NO_DATA;
+        String clockSpeed = Constants.QPROV_CHARACTERISTICS_NO_DATA;
+        String ramUsage = Constants.QPROV_CHARACTERISTICS_NO_DATA;
+        String diskUsage = Constants.QPROV_CHARACTERISTICS_NO_DATA;
+
+        final Optional<HardwareCharacteristics> currentCharacteristicsOptional = extensionStatement.getHardwareCharacteristics().stream()
+                .min(Comparator.comparing(HardwareCharacteristics::getRecordingTime));
+        if (currentCharacteristicsOptional.isPresent()) {
+            // update with the latest usage data
+            final HardwareCharacteristics currentCharacteristics = currentCharacteristicsOptional.get();
+            recordingTime = currentCharacteristics.getRecordingTime().toString();
+            cpuUsage = String.valueOf(currentCharacteristics.getCpuUsage());
+            clockSpeed = String.valueOf(currentCharacteristics.getClockSpeed());
+            ramUsage = String.valueOf(currentCharacteristics.getRamUsage());
+            diskUsage = String.valueOf(currentCharacteristics.getDiskUsage());
+        }
+        agent.getOther().add(Utils.createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_RECORDING_TIME,
+                recordingTime, Constants.QPROV_TYPE_VIRTUAL_MACHINE_RECORDING_TIME + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils.createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_CPU_USAGE,
+                cpuUsage, Constants.QPROV_TYPE_VIRTUAL_MACHINE_CPU_USAGE + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils.createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_CLOCK_SPEED,
+                clockSpeed, Constants.QPROV_TYPE_VIRTUAL_MACHINE_CLOCK_SPEED + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils.createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_RAM_USAGE,
+                ramUsage, Constants.QPROV_TYPE_VIRTUAL_MACHINE_RAM_USAGE + Constants.QPROV_TYPE_SUFFIX));
+        agent.getOther().add(Utils.createOtherElement(Constants.QPROV_TYPE_VIRTUAL_MACHINE_DISK_USAGE,
+                diskUsage, Constants.QPROV_TYPE_VIRTUAL_MACHINE_DISK_USAGE + Constants.QPROV_TYPE_SUFFIX));
+        return Stream.of(agent).collect(Collectors.toCollection(HashSet::new));
+    }
+}

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/CalibrationMatrix.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/CalibrationMatrix.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/ClassicalData.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/ClassicalData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/Gate.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/Gate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/GateCharacteristics.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/GateCharacteristics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/HardwareCharacteristics.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/HardwareCharacteristics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/HardwareCharacteristics.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/HardwareCharacteristics.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.core.model.entities;
+
+import java.util.Date;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.jetbrains.annotations.NotNull;
+import org.quantil.qprov.core.model.agents.VirtualMachine;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+/**
+ * Characteristics of a gate at a certain calibration time
+ */
+@EqualsAndHashCode
+@Data
+@Entity
+public class HardwareCharacteristics implements Comparable<HardwareCharacteristics> {
+
+    @Id
+    @Getter
+    @Setter
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "databaseId", updatable = false, nullable = false)
+    private UUID databaseId;
+
+    private Date recordingTime;
+
+    private float cpuUsage;
+
+    private float clockSpeed;
+
+    private float ramUsage;
+
+    private float diskUsage;
+
+    @ManyToOne
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private VirtualMachine virtualMachine;
+
+    @Override
+    public int compareTo(@NotNull HardwareCharacteristics o) {
+        return getRecordingTime().compareTo(o.getRecordingTime());
+    }
+}

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/QuantumCircuit.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/QuantumCircuit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/Qubit.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/Qubit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/QubitCharacteristics.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/model/entities/QubitCharacteristics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/CalibrationMatrixRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/CalibrationMatrixRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/ClassicalDataRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/ClassicalDataRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/CompileActivityRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/CompileActivityRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/CompilerRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/CompilerRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/DataPreparationServiceRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/DataPreparationServiceRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/ExecuteActivityRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/ExecuteActivityRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/GateCharacteristicsRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/GateCharacteristicsRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/GateRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/GateRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/HardwareCharacteristicsRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/HardwareCharacteristicsRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/HardwareCharacteristicsRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/HardwareCharacteristicsRepository.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.core.repositories;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.quantil.qprov.core.model.agents.VirtualMachine;
+import org.quantil.qprov.core.model.entities.HardwareCharacteristics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@RepositoryRestResource(exported = false)
+@Repository
+public interface HardwareCharacteristicsRepository extends JpaRepository<HardwareCharacteristics, UUID> {
+    List<HardwareCharacteristics> findByVirtualMachineOrderByRecordingTimeDesc(VirtualMachine virtualMachine);
+}

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/PrepareDataActivityRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/PrepareDataActivityRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/ProviderRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/ProviderRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QPURepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QPURepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QuantumCircuitRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QuantumCircuitRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QubitCharacteristicsRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QubitCharacteristicsRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QubitRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/QubitRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/VirtualMachineRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/VirtualMachineRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/VirtualMachineRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/VirtualMachineRepository.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.core.repositories;
+
+import java.util.UUID;
+
+import org.quantil.qprov.core.model.agents.VirtualMachine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+@RepositoryRestResource(exported = false)
+@Repository
+public interface VirtualMachineRepository extends JpaRepository<VirtualMachine, UUID> {
+
+}

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvActivityRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvActivityRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvAgentRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvAgentRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvDocumentRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvDocumentRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvEntityRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvEntityRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvTemplateRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/ProvTemplateRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/QualifiedNameRepository.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/repositories/prov/QualifiedNameRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/utils/ProvInteroperabilityUtils.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/utils/ProvInteroperabilityUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/utils/Utils.java
+++ b/org.quantil.qprov.core/src/main/java/org/quantil/qprov/core/utils/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/Constants.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/Constants.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/Constants.java
@@ -29,6 +29,8 @@ public final class Constants {
 
     public static final String TAG_PROVIDER = "provider";
 
+    public static final String TAG_VIRTUAL_MACHINE = "virtual-machine";
+
     public static final String TAG_PROV = "provenance-document";
 
     public static final String TAG_PROV_TEMPLATE = "provenance-template";
@@ -55,6 +57,8 @@ public final class Constants {
     public static final String PATH_PROV_PARAMETERS = "parameters";
 
     public static final String PATH_PROVIDERS = "providers";
+
+    public static final String PATH_VIRTUAL_MACHINES = "virtual-machines";
 
     public static final String PATH_QPUS = "qpus";
 

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/QProvAPI.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/QProvAPI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/QProvAPIConfig.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/QProvAPIConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/AggregatedDataController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/AggregatedDataController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/GateCharacteristicsController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/GateCharacteristicsController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/GateController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/GateController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/HardwareCharacteristicsController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/HardwareCharacteristicsController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/HardwareCharacteristicsController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/HardwareCharacteristicsController.java
@@ -19,7 +19,6 @@
 
 package org.quantil.qprov.web.controller;
 
-
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
@@ -53,7 +52,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 
 @io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_VIRTUAL_MACHINE)
 @RestController
@@ -138,6 +136,4 @@ public class HardwareCharacteristicsController {
         virtualMachineDto.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachine(virtualMachine.getDatabaseId())).withSelfRel());
         return virtualMachineDto;
     }
-
-
 }

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/HardwareCharacteristicsController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/HardwareCharacteristicsController.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.web.controller;
+
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import javax.ws.rs.QueryParam;
+
+import org.quantil.qprov.core.model.agents.VirtualMachine;
+import org.quantil.qprov.core.model.entities.HardwareCharacteristics;
+import org.quantil.qprov.core.repositories.HardwareCharacteristicsRepository;
+import org.quantil.qprov.core.repositories.VirtualMachineRepository;
+import org.quantil.qprov.web.Constants;
+import org.quantil.qprov.web.dtos.HardwareCharacteristicsDto;
+import org.quantil.qprov.web.dtos.VirtualMachineDto;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+@io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_VIRTUAL_MACHINE)
+@RestController
+@CrossOrigin(allowedHeaders = "*", origins = "*")
+@RequestMapping("/" + Constants.PATH_VIRTUAL_MACHINES + "/{virtualMachineId}/" + Constants.PATH_CHARACTERISTICS)
+@AllArgsConstructor
+@Slf4j
+public class HardwareCharacteristicsController {
+
+    private final VirtualMachineRepository virtualMachineRepository;
+
+    private final HardwareCharacteristicsRepository hardwareCharacteristicsRepository;
+
+    @Operation(responses = {@ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", description = "No characteristics for this Gate available.")}, description =
+            "Retrieve the calibration characteristics from the given gate. " +
+                    "By using the latest parameter only the latest data is retrieved, otherwise all available data.")
+    @GetMapping
+    public ResponseEntity<CollectionModel<EntityModel<HardwareCharacteristicsDto>>> getHardwareCharacteristics(
+            @PathVariable UUID virtualMachineId, @QueryParam("latest") boolean latest) {
+
+        // check availability of virtual machine
+        final Optional<VirtualMachine> virtualMachineOptional = virtualMachineRepository.findById(virtualMachineId);
+        if (virtualMachineOptional.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        final Stream<HardwareCharacteristics> hardwareCharacteristicsStream;
+        if (latest) {
+            // retrieve characteristics with the latest calibration time stamp
+            hardwareCharacteristicsStream = Stream.ofNullable(
+                    hardwareCharacteristicsRepository.findByVirtualMachineOrderByRecordingTimeDesc(virtualMachineOptional.get()).stream()
+                            .findFirst().orElse(null));
+        } else {
+            // retrieve all characteristics
+            hardwareCharacteristicsStream =
+                    hardwareCharacteristicsRepository.findByVirtualMachineOrderByRecordingTimeDesc(virtualMachineOptional.get()).stream();
+        }
+
+        final List<EntityModel<HardwareCharacteristicsDto>> entities = new ArrayList<>();
+        hardwareCharacteristicsStream.forEach(hardwareCharacteristic -> {
+            entities.add(new EntityModel<HardwareCharacteristicsDto>(HardwareCharacteristicsDto.createDTO(hardwareCharacteristic)));
+        });
+
+        if (entities.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        return ResponseEntity.ok(new CollectionModel<>(entities));
+    }
+
+    @Operation(responses = {@ApiResponse(responseCode = "201"),
+    }, description = "Create a new VirtualMachine and return the link which can then be used to retrieve, update, and delete it.")
+    @PutMapping()
+    public ResponseEntity<EntityModel<VirtualMachineDto>> addHardwareCharacteristics(
+            @RequestBody HardwareCharacteristicsDto hardwareCharacteristicsDto, @PathVariable UUID virtualMachineId) {
+
+        final HardwareCharacteristics characteristics = new HardwareCharacteristics();
+        final Optional<VirtualMachine> virtualMachineOptional = virtualMachineRepository.findById(virtualMachineId);
+
+        if (virtualMachineOptional.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        final VirtualMachine virtualMachine = virtualMachineOptional.get();
+
+        characteristics.setCpuUsage(hardwareCharacteristicsDto.getCpuUsage());
+        characteristics.setClockSpeed(hardwareCharacteristicsDto.getClockSpeed());
+        characteristics.setDiskUsage(hardwareCharacteristicsDto.getDiskUsage());
+        characteristics.setRamUsage(hardwareCharacteristicsDto.getRamUsage());
+        characteristics.setRecordingTime(hardwareCharacteristicsDto.getRecordingTime());
+        characteristics.setVirtualMachine(virtualMachine);
+        virtualMachine.getHardwareCharacteristics().add(characteristics);
+
+        virtualMachineRepository.save(virtualMachine);
+
+        return new ResponseEntity<>(createEntityModel(virtualMachine), HttpStatus.CREATED);
+    }
+
+    private EntityModel<VirtualMachineDto> createEntityModel(VirtualMachine virtualMachine) {
+        final EntityModel<VirtualMachineDto> virtualMachineDto = new EntityModel<VirtualMachineDto>(VirtualMachineDto.createDTO(virtualMachine));
+        virtualMachineDto.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachine(virtualMachine.getDatabaseId())).withSelfRel());
+        return virtualMachineDto;
+    }
+
+
+}

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvActivityController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvActivityController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvAgentController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvAgentController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvDocumentController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvDocumentController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvEntityController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvEntityController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvTemplateController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProvTemplateController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProviderController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/ProviderController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/QpuController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/QpuController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/QubitCharacteristicsController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/QubitCharacteristicsController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/QubitController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/QubitController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/RootController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/RootController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/VirtualMachineController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/VirtualMachineController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/VirtualMachineController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/VirtualMachineController.java
@@ -132,8 +132,6 @@ public class VirtualMachineController {
         virtualMachineDto.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachine(virtualMachine.getDatabaseId())).withSelfRel());
         return virtualMachineDto;
     }
-
-
 }
 
 

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/VirtualMachineController.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/controller/VirtualMachineController.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.web.controller;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.quantil.qprov.core.model.agents.VirtualMachine;
+import org.quantil.qprov.core.repositories.VirtualMachineRepository;
+import org.quantil.qprov.web.Constants;
+import org.quantil.qprov.web.dtos.VirtualMachineDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@io.swagger.v3.oas.annotations.tags.Tag(name = Constants.TAG_VIRTUAL_MACHINE)
+@RestController
+@CrossOrigin(allowedHeaders = "*", origins = "*")
+@RequestMapping("/" + Constants.PATH_VIRTUAL_MACHINES)
+@AllArgsConstructor
+@Slf4j
+public class VirtualMachineController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ProviderController.class);
+
+    private final VirtualMachineRepository virtualMachineRepository;
+
+    @Operation(responses = {@ApiResponse(responseCode = "200")}, description = "Retrieve all classical hardware virtual machines.")
+    @GetMapping
+    public ResponseEntity<CollectionModel<EntityModel<VirtualMachineDto>>> getVirtualMachines() {
+        final List<EntityModel<VirtualMachineDto>> virtualMachineEntities = new ArrayList<>();
+
+        final List<Link> virtualMachineLinks = new ArrayList<>();
+        virtualMachineRepository.findAll().forEach((VirtualMachine virtualMachine) -> {
+            logger.debug("Found VirtualMachine with name: {}", virtualMachine.getName());
+            final EntityModel<VirtualMachineDto> virtualMachineDto = new EntityModel<VirtualMachineDto>(VirtualMachineDto.createDTO(virtualMachine));
+            virtualMachineDto.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachine(virtualMachine.getDatabaseId())).withSelfRel());
+            virtualMachineDto.add(linkTo(methodOn(HardwareCharacteristicsController.class).getHardwareCharacteristics(virtualMachine.getDatabaseId(),
+                    false)).withRel(Constants.PATH_CHARACTERISTICS));
+            virtualMachineLinks.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachine(virtualMachine.getDatabaseId())).withRel(
+                    virtualMachine.getDatabaseId().toString()));
+            virtualMachineEntities.add(virtualMachineDto);
+        });
+
+        final var collectionModel = new CollectionModel<>(virtualMachineEntities);
+        collectionModel.add(virtualMachineLinks);
+        collectionModel.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachines()).withSelfRel());
+        return ResponseEntity.ok(collectionModel);
+    }
+
+    @Operation(responses = {@ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", description = "Not Found. VirtualMachine with given ID doesn't exist.")},
+            description = "Retrieve a specific VirtualMachine and its basic properties.")
+    @GetMapping("/{virtualMachineId}")
+    public ResponseEntity<EntityModel<VirtualMachineDto>> getVirtualMachine(@PathVariable UUID virtualMachineId) {
+
+        final Optional<VirtualMachine> virtualMachine = virtualMachineRepository.findById(virtualMachineId);
+        if (virtualMachine.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        final EntityModel<VirtualMachineDto> virtualMachineDto =
+                new EntityModel<VirtualMachineDto>(VirtualMachineDto.createDTO(virtualMachine.get()));
+        virtualMachineDto.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachine(virtualMachineId)).withSelfRel());
+        virtualMachineDto.add(
+                linkTo(methodOn(HardwareCharacteristicsController.class).getHardwareCharacteristics(virtualMachine.get().getDatabaseId(),
+                        false)).withRel(Constants.PATH_CHARACTERISTICS));
+        return ResponseEntity.ok(virtualMachineDto);
+    }
+
+    @Operation(responses = {
+            @ApiResponse(responseCode = "201"), },
+            description = "Create a new VirtualMachine and return the link which can then be used to retrieve, update, and delete it.")
+    @PostMapping
+    public ResponseEntity<EntityModel<VirtualMachineDto>> createVirtualMachine(@RequestBody VirtualMachineDto virtualMachineDto) {
+
+        final VirtualMachine virtualMachine = new VirtualMachine();
+        virtualMachine.setName(virtualMachineDto.getName());
+        virtualMachine.setCpu(virtualMachineDto.getCpu());
+        virtualMachine.setCpuCores(virtualMachineDto.getCpuCores());
+        virtualMachine.setRamSize(virtualMachineDto.getRamSize());
+        virtualMachine.setDiskSize(virtualMachineDto.getDiskSize());
+        virtualMachine.setHardwareCharacteristics(new HashSet<>());
+
+
+        virtualMachineRepository.save(virtualMachine);
+
+        return new ResponseEntity<>(createEntityModel(virtualMachine), HttpStatus.CREATED);
+    }
+
+    private EntityModel<VirtualMachineDto> createEntityModel(VirtualMachine virtualMachine) {
+        final EntityModel<VirtualMachineDto> virtualMachineDto = new EntityModel<VirtualMachineDto>(VirtualMachineDto.createDTO(virtualMachine));
+        virtualMachineDto.add(linkTo(methodOn(VirtualMachineController.class).getVirtualMachine(virtualMachine.getDatabaseId())).withSelfRel());
+        return virtualMachineDto;
+    }
+
+
+}
+
+

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/CalibrationMatrixDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/CalibrationMatrixDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/GateCharacteristicsDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/GateCharacteristicsDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/GateDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/GateDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/HardwareCharacteristicsDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/HardwareCharacteristicsDto.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.web.dtos;
+
+import java.util.Date;
+import java.util.UUID;
+
+import org.quantil.qprov.core.model.entities.HardwareCharacteristics;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Data transfer object for hardware characteristics ({@link org.quantil.qprov.core.model.entities.HardwareCharacteristics}).
+ */
+@EqualsAndHashCode
+@Data
+@AllArgsConstructor
+public class HardwareCharacteristicsDto {
+
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    private UUID id;
+
+    private Date recordingTime;
+
+    private float cpuUsage;
+
+    private float clockSpeed;
+
+    private float ramUsage;
+
+    private float diskUsage;
+
+    public static HardwareCharacteristicsDto createDTO(HardwareCharacteristics hardwareCharacteristics) {
+        return new HardwareCharacteristicsDto(hardwareCharacteristics.getDatabaseId(),
+                hardwareCharacteristics.getRecordingTime(), hardwareCharacteristics.getCpuUsage(),
+                hardwareCharacteristics.getClockSpeed(),
+                hardwareCharacteristics.getRamUsage(), hardwareCharacteristics.getDiskUsage());
+    }
+
+
+}

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/HardwareCharacteristicsDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/HardwareCharacteristicsDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/HardwareCharacteristicsDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/HardwareCharacteristicsDto.java
@@ -56,6 +56,4 @@ public class HardwareCharacteristicsDto {
                 hardwareCharacteristics.getClockSpeed(),
                 hardwareCharacteristics.getRamUsage(), hardwareCharacteristics.getDiskUsage());
     }
-
-
 }

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvActivityDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvActivityDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvAgentDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvAgentDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvDocumentDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvDocumentDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvEntityDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvEntityDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvNamespaceDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProvNamespaceDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProviderDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/ProviderDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/QpuDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/QpuDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/QubitCharacteristicsDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/QubitCharacteristicsDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/QubitDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/QubitDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/VirtualMachineDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/VirtualMachineDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 the QProv contributors.
+ * Copyright (c) 2023 the QProv contributors.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/VirtualMachineDto.java
+++ b/org.quantil.qprov.web/src/main/java/org/quantil/qprov/web/dtos/VirtualMachineDto.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2020 the QProv contributors.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.quantil.qprov.web.dtos;
+
+import java.util.UUID;
+
+import org.quantil.qprov.core.model.agents.VirtualMachine;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Data transfer object for VirtualMachines ({@link org.quantil.qprov.core.model.agents.VirtualMachine}).
+ */
+@EqualsAndHashCode
+@Data
+@AllArgsConstructor
+public class VirtualMachineDto {
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    private UUID id;
+
+    private String name;
+
+    private String cpu;
+
+    private int cpuCores;
+
+    private int ramSize;
+
+    private int diskSize;
+
+    public static VirtualMachineDto createDTO(VirtualMachine virtualMachine) {
+        return new VirtualMachineDto(virtualMachine.getDatabaseId(), virtualMachine.getName(), virtualMachine.getCpu(),
+                virtualMachine.getCpuCores(), virtualMachine.getRamSize(), virtualMachine.getDiskSize());
+    }
+}


### PR DESCRIPTION
Add endpoints and data classes to work with the new tosca nodetype monitoredVM implemented in [this PR](https://github.com/OpenTOSCA/tosca-definitions-common/pull/40)